### PR TITLE
Add camera utils and sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a minimal example of a CCTV map running locally with PH
 
 - `cameras.json` – sample camera definitions
 - `camera_utils.php` – helper functions for generating snapshot and panel URLs with authentication handled per vendor
+- `snapshot.php` – server-side proxy that fetches snapshots to avoid browser cross-origin issues
 - `auth.php` – list of allowed users
 - `login.php` / `logout.php` – simple authentication
 - `index.php` – the map view shown after logging in
@@ -25,9 +26,9 @@ Each camera entry may contain the following fields:
 
 Snapshot and panel URLs are derived at runtime using the helper functions.
 
-Snapshot URLs are built automatically based on the camera vendor and embed
-credentials in the URL (username and password are percent‑encoded to handle
-special characters). For example:
+Snapshots are fetched server-side. The helper functions build the vendor-specific
+URL including percent-encoded credentials, and `snapshot.php` retrieves the image
+and serves it to the browser. Examples of the underlying camera endpoints:
 
 - Hikvision: `http://user:pass@IP/ISAPI/Streaming/Channels/101/picture`
 - Dahua: `http://user:pass@IP/cgi-bin/snapshot.cgi?channel=1`
@@ -48,6 +49,7 @@ special characters). For example:
 
 - Leaflet map showing cameras from `cameras.json`
 - Manual refresh of snapshots in the camera popups
+- Snapshots are served through `snapshot.php` to prevent browser cross-origin errors
 - Copy-to-clipboard buttons for IP, username and password (password can be shown/hidden)
 - Bootstrap theme toggle with the selected option stored in a cookie
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a minimal example of a CCTV map running locally with PH
 ## Files
 
 - `cameras.json` – sample camera definitions
-- `camera_utils.php` – helper functions for generating snapshot and panel URLs with authentication handled per vendor
+- `camera_utils.php` – helper functions for generating snapshot and panel URLs and a small slug helper
 - `snapshot.php` – server-side proxy that fetches snapshots to avoid browser cross-origin issues
 - `auth.php` – list of allowed users
 - `login.php` / `logout.php` – simple authentication
@@ -15,7 +15,7 @@ This repository contains a minimal example of a CCTV map running locally with PH
 
 Each camera entry may contain the following fields:
 
-- `id` – unique identifier
+- `name` – human readable name of the device
 - `ip` – address of the device
 - `username` / `password` – credentials for the camera
 - `manufacturer` – camera vendor (Hikvision, Dahua, BCS)
@@ -24,15 +24,14 @@ Each camera entry may contain the following fields:
 - `type` – camera type (ptz, bullet, etc.)
 - `mac` – optional MAC address
 
-Snapshot and panel URLs are derived at runtime using the helper functions.
+The camera ID used internally is derived from `name` by creating a simple slug (lowercase alphanumeric with dashes). Snapshot and panel URLs are built at runtime using the helper functions.
 
-Snapshots are fetched server-side. The helper functions build the vendor-specific
-URL including percent-encoded credentials, and `snapshot.php` retrieves the image
-and serves it to the browser. Examples of the underlying camera endpoints:
+Snapshots are fetched server-side. The helper functions build the vendor-specific URL, and `snapshot.php` retrieves the image using HTTP authentication before serving it to the browser. Examples of the underlying camera endpoints:
 
-- Hikvision: `http://user:pass@IP/ISAPI/Streaming/Channels/101/picture`
-- Dahua: `http://user:pass@IP/cgi-bin/snapshot.cgi?channel=1`
-- BCS (Hikvision compatible): `http://user:pass@IP/ISAPI/Streaming/channels/1/picture`
+- Hikvision: `http://IP/ISAPI/Streaming/Channels/101/picture`
+- Dahua: `http://IP/cgi-bin/snapshot.cgi?channel=1`
+- BCS (Hikvision compatible): `http://IP/ISAPI/Streaming/channels/1/picture`
+
 ## Running
 
 1. Install PHP (only the CLI is required). On Debian/Ubuntu:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# cctvmap
+# CCTV Map
+
+This repository contains a minimal example of a CCTV map running locally with PHP, Leaflet and Bootstrap.
+
+## Files
+
+- `cameras.json` – sample camera definitions
+- `camera_utils.php` – helper functions for generating snapshot and panel URLs
+- `auth.php` – list of allowed users
+- `login.php` / `logout.php` – simple authentication
+- `index.php` – the map view shown after logging in
+
+## Camera definition
+
+Each camera entry may contain the following fields:
+
+- `id` – unique identifier
+- `ip` – address of the device
+- `username` / `password` – credentials for the camera
+- `manufacturer` – camera vendor (Hikvision, Dahua, BCS)
+- `lat` / `lng` – geographic coordinates
+- `direction` – orientation in degrees
+- `type` – camera type (ptz, bullet, etc.)
+- `mac` – optional MAC address
+
+Snapshot and panel URLs are derived at runtime using the helper functions.
+
+## Running
+
+1. Install PHP (only the CLI is required). On Debian/Ubuntu:
+   ```sh
+   sudo apt-get install php-cli
+   ```
+2. Start the built-in PHP server from the repository root:
+   ```sh
+   php -S localhost:8000
+   ```
+3. Open `http://localhost:8000/login.php` in your browser and log in using the sample credentials (`admin`/`admin`).
+
+The map will load cameras from `cameras.json` and display them on a Leaflet map with snapshots and links to the camera panels.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Each camera entry may contain the following fields:
 
 Snapshot and panel URLs are derived at runtime using the helper functions.
 
-Snapshot URLs are built automatically based on the camera vendor and embed credentials in the URL. For example:
+Snapshot URLs are built automatically based on the camera vendor and embed
+credentials in the URL (username and password are percent‑encoded to handle
+special characters). For example:
 
 - Hikvision: `http://user:pass@IP/ISAPI/Streaming/Channels/101/picture`
 - Dahua: `http://user:pass@IP/cgi-bin/snapshot.cgi?channel=1`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a minimal example of a CCTV map running locally with PH
 ## Files
 
 - `cameras.json` – sample camera definitions
-- `camera_utils.php` – helper functions for generating snapshot and panel URLs
+- `camera_utils.php` – helper functions for generating snapshot and panel URLs with authentication handled per vendor
 - `auth.php` – list of allowed users
 - `login.php` / `logout.php` – simple authentication
 - `index.php` – the map view shown after logging in
@@ -25,6 +25,7 @@ Each camera entry may contain the following fields:
 
 Snapshot and panel URLs are derived at runtime using the helper functions.
 
+Snapshot URLs are built automatically based on the manufacturer and include the credentials so the map can display images.
 ## Running
 
 1. Install PHP (only the CLI is required). On Debian/Ubuntu:

--- a/README.md
+++ b/README.md
@@ -37,4 +37,11 @@ Snapshot and panel URLs are derived at runtime using the helper functions.
    ```
 3. Open `http://localhost:8000/login.php` in your browser and log in using the sample credentials (`admin`/`admin`).
 
-The map will load cameras from `cameras.json` and display them on a Leaflet map with snapshots and links to the camera panels.
+## Features
+
+- Leaflet map showing cameras from `cameras.json`
+- Manual refresh of snapshots in the camera popups
+- Copy-to-clipboard buttons for IP, username and password (password can be shown/hidden)
+- Bootstrap theme toggle with the selected option stored in a cookie
+
+The map will load cameras from `cameras.json` and display them with custom markers and popups including the latest snapshot and a link to the camera panel.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ Each camera entry may contain the following fields:
 
 Snapshot and panel URLs are derived at runtime using the helper functions.
 
-Snapshot URLs are built automatically based on the manufacturer and include the credentials so the map can display images.
+Snapshot URLs are built automatically based on the camera vendor and embed credentials in the URL. For example:
+
+- Hikvision: `http://user:pass@IP/ISAPI/Streaming/Channels/101/picture`
+- Dahua: `http://user:pass@IP/cgi-bin/snapshot.cgi?channel=1`
+- BCS (Hikvision compatible): `http://user:pass@IP/ISAPI/Streaming/channels/1/picture`
 ## Running
 
 1. Install PHP (only the CLI is required). On Debian/Ubuntu:

--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,5 @@
+<?php
+$USERS = [
+    'admin' => 'admin'
+];
+?>

--- a/camera_utils.php
+++ b/camera_utils.php
@@ -1,13 +1,13 @@
 <?php
 function snapshot_url(array $cam): ?string {
     $ip = $cam['ip'];
-    $user = $cam['username'] ?? '';
-    $pass = $cam['password'] ?? '';
+    $user = rawurlencode($cam['username'] ?? '');
+    $pass = rawurlencode($cam['password'] ?? '');
     $manufacturer = strtolower($cam['manufacturer'] ?? '');
     switch ($manufacturer) {
         case 'hikvision':
-            // Hikvision uses the ISAPI endpoint with HTTP basic auth
-            return "http://{$user}:{$pass}@{$ip}/ISAPI/Streaming/channels/101/picture?snapshot=now";
+            // Hikvision snapshot endpoint
+            return "http://{$user}:{$pass}@{$ip}/ISAPI/Streaming/Channels/101/picture";
         case 'dahua':
             // Dahua accepts credentials in the URL like user:pass@host
             return "http://{$user}:{$pass}@{$ip}/cgi-bin/snapshot.cgi?channel=1";

--- a/camera_utils.php
+++ b/camera_utils.php
@@ -9,8 +9,8 @@ function snapshot_url(array $cam): ?string {
             // Hikvision uses the ISAPI endpoint with HTTP basic auth
             return "http://{$user}:{$pass}@{$ip}/ISAPI/Streaming/channels/101/picture?snapshot=now";
         case 'dahua':
-            // Dahua allows credentials via query parameters
-            return "http://{$ip}/cgi-bin/snapshot.cgi?channel=1&user={$user}&password={$pass}";
+            // Dahua accepts credentials in the URL like user:pass@host
+            return "http://{$user}:{$pass}@{$ip}/cgi-bin/snapshot.cgi?channel=1";
         case 'bcs':
             // Many BCS devices implement Hikvision's ISAPI
             return "http://{$user}:{$pass}@{$ip}/ISAPI/Streaming/channels/1/picture";

--- a/camera_utils.php
+++ b/camera_utils.php
@@ -1,14 +1,19 @@
 <?php
 function snapshot_url(array $cam): ?string {
     $ip = $cam['ip'];
+    $user = $cam['username'] ?? '';
+    $pass = $cam['password'] ?? '';
     $manufacturer = strtolower($cam['manufacturer'] ?? '');
     switch ($manufacturer) {
         case 'hikvision':
-            return "http://$ip/ISAPI/Streaming/channels/101/picture?snapshot=now";
+            // Hikvision uses the ISAPI endpoint with HTTP basic auth
+            return "http://{$user}:{$pass}@{$ip}/ISAPI/Streaming/channels/101/picture?snapshot=now";
         case 'dahua':
-            return "http://$ip/cgi-bin/snapshot.cgi";
+            // Dahua allows credentials via query parameters
+            return "http://{$ip}/cgi-bin/snapshot.cgi?channel=1&user={$user}&password={$pass}";
         case 'bcs':
-            return "http://$ip/ISAPI/Streaming/channels/1/picture";
+            // Many BCS devices implement Hikvision's ISAPI
+            return "http://{$user}:{$pass}@{$ip}/ISAPI/Streaming/channels/1/picture";
         default:
             return null;
     }

--- a/camera_utils.php
+++ b/camera_utils.php
@@ -1,0 +1,19 @@
+<?php
+function snapshot_url(array $cam): ?string {
+    $ip = $cam['ip'];
+    $manufacturer = strtolower($cam['manufacturer'] ?? '');
+    switch ($manufacturer) {
+        case 'hikvision':
+            return "http://$ip/ISAPI/Streaming/channels/101/picture?snapshot=now";
+        case 'dahua':
+            return "http://$ip/cgi-bin/snapshot.cgi";
+        case 'bcs':
+            return "http://$ip/ISAPI/Streaming/channels/1/picture";
+        default:
+            return null;
+    }
+}
+
+function panel_url(array $cam): string {
+    return "http://" . $cam['ip'];
+}

--- a/camera_utils.php
+++ b/camera_utils.php
@@ -1,19 +1,22 @@
 <?php
+function slugify(string $text): string {
+    $text = iconv('UTF-8', 'ASCII//TRANSLIT', $text);
+    $text = strtolower($text);
+    $text = preg_replace('/[^a-z0-9]+/', '-', $text);
+    $text = trim($text, '-');
+    return $text ?: 'cam';
+}
+
 function snapshot_url(array $cam): ?string {
     $ip = $cam['ip'];
-    $user = rawurlencode($cam['username'] ?? '');
-    $pass = rawurlencode($cam['password'] ?? '');
     $manufacturer = strtolower($cam['manufacturer'] ?? '');
     switch ($manufacturer) {
         case 'hikvision':
-            // Hikvision snapshot endpoint
-            return "http://{$user}:{$pass}@{$ip}/ISAPI/Streaming/Channels/101/picture";
+            return "http://{$ip}/ISAPI/Streaming/Channels/101/picture";
         case 'dahua':
-            // Dahua accepts credentials in the URL like user:pass@host
-            return "http://{$user}:{$pass}@{$ip}/cgi-bin/snapshot.cgi?channel=1";
+            return "http://{$ip}/cgi-bin/snapshot.cgi?channel=1";
         case 'bcs':
-            // Many BCS devices implement Hikvision's ISAPI
-            return "http://{$user}:{$pass}@{$ip}/ISAPI/Streaming/channels/1/picture";
+            return "http://{$ip}/ISAPI/Streaming/channels/1/picture";
         default:
             return null;
     }
@@ -22,3 +25,4 @@ function snapshot_url(array $cam): ?string {
 function panel_url(array $cam): string {
     return "http://" . $cam['ip'];
 }
+?>

--- a/cameras.json
+++ b/cameras.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "cam001",
+    "name": "Wejście główne PTZ",
     "ip": "192.168.1.10",
     "username": "user",
     "password": "pass",
@@ -12,7 +12,7 @@
     "mac": "00:11:22:33:44:55"
   },
   {
-    "id": "cam002",
+    "name": "Parking - kamera bullet",
     "ip": "192.168.1.11",
     "username": "user",
     "password": "pass",

--- a/cameras.json
+++ b/cameras.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "cam001",
+    "ip": "192.168.1.10",
+    "username": "user",
+    "password": "pass",
+    "manufacturer": "Hikvision",
+    "lat": 52.1234,
+    "lng": 20.4321,
+    "direction": 90,
+    "type": "ptz",
+    "mac": "00:11:22:33:44:55"
+  },
+  {
+    "id": "cam002",
+    "ip": "192.168.1.11",
+    "username": "user",
+    "password": "pass",
+    "manufacturer": "Dahua",
+    "lat": 52.1238,
+    "lng": 20.4325,
+    "direction": 180,
+    "type": "bullet"
+  }
+]

--- a/index.php
+++ b/index.php
@@ -17,13 +17,18 @@ foreach ($cams as &$cam) {
 <meta charset="UTF-8">
 <title>CCTV Map</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css" />
-<style>#map{height:80vh;}</style>
+<style>
+#map{height:80vh;}
+.bullet-icon{width:0;height:0;border-left:8px solid transparent;border-right:8px solid transparent;border-top:14px solid red;}
+</style>
 </head>
 <body>
-<nav class="navbar navbar-light bg-light">
-  <div class="container-fluid">
-    <span class="navbar-brand">CCTV Map</span>
+<nav class="navbar navbar-light bg-light px-3">
+  <span class="navbar-brand">CCTV Map</span>
+  <div class="ms-auto d-flex gap-2">
+    <button id="theme-toggle" class="btn btn-outline-secondary"><i id="theme-icon" class="fa-solid fa-moon"></i></button>
     <a class="btn btn-outline-danger" href="logout.php">Logout</a>
   </div>
 </nav>
@@ -31,23 +36,70 @@ foreach ($cams as &$cam) {
 <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 const cameras = <?php echo json_encode($cams, JSON_HEX_TAG|JSON_UNESCAPED_SLASHES); ?>;
+function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]+)');return m?m.pop():'';}
+function setTheme(t){document.documentElement.setAttribute('data-bs-theme',t);document.cookie='theme='+t+';path=/';}
+document.addEventListener('DOMContentLoaded',()=>{
+  const saved=getCookie('theme')||'light';
+  setTheme(saved);
+  const icon=document.getElementById('theme-icon');
+  icon.classList.toggle('fa-sun',saved==='dark');
+  icon.classList.toggle('fa-moon',saved!=='dark');
+  document.getElementById('theme-toggle').addEventListener('click',()=>{
+    const cur=document.documentElement.getAttribute('data-bs-theme');
+    const next=cur==='dark'?'light':'dark';
+    setTheme(next);
+    icon.classList.toggle('fa-sun');
+    icon.classList.toggle('fa-moon');
+  });
+});
+const map=L.map('map').setView([cameras[0]?.lat||0,cameras[0]?.lng||0],13);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{attribution:'Map data © OpenStreetMap contributors'}).addTo(map);
+function popupHtml(cam){
+  return `<div><strong>${cam.id}</strong><br>
+    <img id="snap_${cam.id}" data-src="${cam.snapshot}" src="${cam.snapshot}" width="200" class="img-fluid mb-1">
+    <button class="btn btn-sm btn-outline-secondary refresh" data-id="${cam.id}"><i class="fa-solid fa-arrows-rotate"></i></button><br>
+    IP: <span id="ip_${cam.id}" class="data-text">${cam.ip}</span>
+    <button class="btn btn-sm btn-link copy-btn p-0" data-target="ip_${cam.id}"><i class="fa-solid fa-copy"></i></button><br>
+    User: <span id="user_${cam.id}" class="data-text">${cam.username}</span>
+    <button class="btn btn-sm btn-link copy-btn p-0" data-target="user_${cam.id}"><i class="fa-solid fa-copy"></i></button><br>
+    Pass: <span id="pass_${cam.id}" class="data-text" data-value="${cam.password}">••••</span>
+    <button class="btn btn-sm btn-link copy-btn p-0" data-target="pass_${cam.id}"><i class="fa-solid fa-copy"></i></button>
+    <button class="btn btn-sm btn-link show-btn p-0" data-target="pass_${cam.id}"><i class="fa-solid fa-eye"></i></button><br>
+    <a href="${cam.panel}" target="_blank">Panel</a></div>`;
+}
+function addEvents(container){
+  container.querySelectorAll('.copy-btn').forEach(btn=>{
+    btn.addEventListener('click',()=>{
+      const t=document.getElementById(btn.dataset.target);
+      const val=t.dataset.value||t.textContent;navigator.clipboard.writeText(val);
+    });
+  });
+  container.querySelectorAll('.show-btn').forEach(btn=>{
+    btn.addEventListener('click',()=>{
+      const t=document.getElementById(btn.dataset.target);
+      const eye=btn.querySelector('i');
+      if(t.textContent==='••••'){t.textContent=t.dataset.value;eye.classList.replace('fa-eye','fa-eye-slash');}
+      else{t.textContent='••••';eye.classList.replace('fa-eye-slash','fa-eye');}
+    });
+  });
+  container.querySelectorAll('.refresh').forEach(btn=>{
+    btn.addEventListener('click',()=>{
+      const img=document.getElementById('snap_'+btn.dataset.id);
+      img.src=img.dataset.src+(img.dataset.src.includes('?')?'&':'?')+'t='+Date.now();
+    });
+  });
+}
 
-const map = L.map('map').setView([cameras[0]?.lat || 0, cameras[0]?.lng || 0], 13);
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  attribution: 'Map data © OpenStreetMap contributors'
-}).addTo(map);
-
-cameras.forEach(cam => {
-  const marker = L.marker([cam.lat, cam.lng]).addTo(map);
-  const popup = `
-    <strong>${cam.id}</strong><br>
-    <img src="${cam.snapshot}" width="200"><br>
-    IP: ${cam.ip}<br>
-    User: ${cam.username}<br>
-    Pass: ${cam.password}<br>
-    <a href="${cam.panel}" target="_blank">Panel</a>
-  `;
-  marker.bindPopup(popup);
+cameras.forEach(cam=>{
+  let marker;
+  if((cam.type||'').toLowerCase()==='ptz'){
+    marker=L.circleMarker([cam.lat,cam.lng],{radius:8,color:'#0d6efd',fillColor:'#0d6efd',fillOpacity:1}).addTo(map);
+  }else{
+    const icon=L.divIcon({className:'',html:`<div class="bullet-icon" style="transform:rotate(${cam.direction||0}deg)"></div>`,iconSize:[20,20],iconAnchor:[10,10]});
+    marker=L.marker([cam.lat,cam.lng],{icon}).addTo(map);
+  }
+  marker.bindPopup(popupHtml(cam));
+  marker.on('popupopen',e=>addEvents(e.popup.getElement()));
 });
 </script>
 </body>

--- a/index.php
+++ b/index.php
@@ -7,6 +7,7 @@ if (!isset($_SESSION['user'])) {
 require_once 'camera_utils.php';
 $cams = json_decode(file_get_contents('cameras.json'), true) ?? [];
 foreach ($cams as &$cam) {
+    $cam['id'] = slugify($cam['name']);
     $cam['snapshot'] = 'snapshot.php?id=' . rawurlencode($cam['id']);
     $cam['panel'] = panel_url($cam);
 }
@@ -55,17 +56,22 @@ document.addEventListener('DOMContentLoaded',()=>{
 const map=L.map('map').setView([cameras[0]?.lat||0,cameras[0]?.lng||0],13);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{attribution:'Map data © OpenStreetMap contributors'}).addTo(map);
 function popupHtml(cam){
-  return `<div><strong>${cam.id}</strong><br>
-    <img id="snap_${cam.id}" data-src="${cam.snapshot}" src="${cam.snapshot}" width="200" class="img-fluid mb-1">
-    <button class="btn btn-sm btn-outline-secondary refresh" data-id="${cam.id}"><i class="fa-solid fa-arrows-rotate"></i></button><br>
-    IP: <span id="ip_${cam.id}" class="data-text">${cam.ip}</span>
-    <button class="btn btn-sm btn-link copy-btn p-0" data-target="ip_${cam.id}"><i class="fa-solid fa-copy"></i></button><br>
-    User: <span id="user_${cam.id}" class="data-text">${cam.username}</span>
-    <button class="btn btn-sm btn-link copy-btn p-0" data-target="user_${cam.id}"><i class="fa-solid fa-copy"></i></button><br>
-    Pass: <span id="pass_${cam.id}" class="data-text" data-value="${cam.password}">••••</span>
-    <button class="btn btn-sm btn-link copy-btn p-0" data-target="pass_${cam.id}"><i class="fa-solid fa-copy"></i></button>
-    <button class="btn btn-sm btn-link show-btn p-0" data-target="pass_${cam.id}"><i class="fa-solid fa-eye"></i></button><br>
-    <a href="${cam.panel}" target="_blank">Panel</a></div>`;
+  return `<div style="max-width:550px;">
+    <h6 class="mb-2">${cam.name}</h6>
+    <img id="snap_${cam.id}" data-src="${cam.snapshot}" src="${cam.snapshot}" class="img-fluid mb-2">
+    <button class="btn btn-sm btn-outline-secondary refresh mb-2" data-id="${cam.id}"><i class="fa-solid fa-arrows-rotate"></i></button>
+    <div class="mb-1">IP: <span id="ip_${cam.id}" class="me-1">${cam.ip}</span>
+      <button class="btn btn-sm btn-link copy-btn p-0" data-target="ip_${cam.id}"><i class="fa-solid fa-copy"></i></button>
+    </div>
+    <div class="mb-1">User: <span id="user_${cam.id}" class="me-1">${cam.username}</span>
+      <button class="btn btn-sm btn-link copy-btn p-0" data-target="user_${cam.id}"><i class="fa-solid fa-copy"></i></button>
+    </div>
+    <div class="mb-1">Pass: <span id="pass_${cam.id}" data-value="${cam.password}" class="me-1">••••</span>
+      <button class="btn btn-sm btn-link copy-btn p-0" data-target="pass_${cam.id}"><i class="fa-solid fa-copy"></i></button>
+      <button class="btn btn-sm btn-link show-btn p-0" data-target="pass_${cam.id}"><i class="fa-solid fa-eye"></i></button>
+    </div>
+    <a href="${cam.panel}" target="_blank" class="btn btn-sm btn-primary">Panel</a>
+  </div>`;
 }
 function addEvents(container){
   container.querySelectorAll('.copy-btn').forEach(btn=>{

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@ if (!isset($_SESSION['user'])) {
 require_once 'camera_utils.php';
 $cams = json_decode(file_get_contents('cameras.json'), true) ?? [];
 foreach ($cams as &$cam) {
-    $cam['snapshot'] = snapshot_url($cam);
+    $cam['snapshot'] = 'snapshot.php?id=' . rawurlencode($cam['id']);
     $cam['panel'] = panel_url($cam);
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,54 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    header('Location: login.php');
+    exit;
+}
+require_once 'camera_utils.php';
+$cams = json_decode(file_get_contents('cameras.json'), true) ?? [];
+foreach ($cams as &$cam) {
+    $cam['snapshot'] = snapshot_url($cam);
+    $cam['panel'] = panel_url($cam);
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>CCTV Map</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.css" />
+<style>#map{height:80vh;}</style>
+</head>
+<body>
+<nav class="navbar navbar-light bg-light">
+  <div class="container-fluid">
+    <span class="navbar-brand">CCTV Map</span>
+    <a class="btn btn-outline-danger" href="logout.php">Logout</a>
+  </div>
+</nav>
+<div id="map"></div>
+<script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+const cameras = <?php echo json_encode($cams, JSON_HEX_TAG|JSON_UNESCAPED_SLASHES); ?>;
+
+const map = L.map('map').setView([cameras[0]?.lat || 0, cameras[0]?.lng || 0], 13);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: 'Map data © OpenStreetMap contributors'
+}).addTo(map);
+
+cameras.forEach(cam => {
+  const marker = L.marker([cam.lat, cam.lng]).addTo(map);
+  const popup = `
+    <strong>${cam.id}</strong><br>
+    <img src="${cam.snapshot}" width="200"><br>
+    IP: ${cam.ip}<br>
+    User: ${cam.username}<br>
+    Pass: ${cam.password}<br>
+    <a href="${cam.panel}" target="_blank">Panel</a>
+  `;
+  marker.bindPopup(popup);
+});
+</script>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -25,8 +25,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <title>Login</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css">
 </head>
-<body class="container py-5">
+<body class="container py-5 position-relative">
+<button id="theme-toggle" class="btn btn-outline-secondary position-absolute top-0 end-0 mt-3 me-3"><i id="theme-icon" class="fa-solid fa-moon"></i></button>
 <h1 class="mb-4">CCTV Login</h1>
 <?php if ($error): ?>
 <div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
@@ -42,5 +44,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   </div>
   <button type="submit" class="btn btn-primary">Login</button>
 </form>
+<script>
+function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]+)');return m?m.pop():'';}
+function setTheme(t){document.documentElement.setAttribute('data-bs-theme',t);document.cookie='theme='+t+';path=/';}
+document.addEventListener('DOMContentLoaded',()=>{
+  const saved=getCookie('theme')||'light';
+  setTheme(saved);
+  const icon=document.getElementById('theme-icon');
+  icon.classList.toggle('fa-sun',saved==='dark');
+  icon.classList.toggle('fa-moon',saved!=='dark');
+  document.getElementById('theme-toggle').addEventListener('click',()=>{
+    const cur=document.documentElement.getAttribute('data-bs-theme');
+    const next=cur==='dark'?'light':'dark';
+    setTheme(next);
+    icon.classList.toggle('fa-sun');
+    icon.classList.toggle('fa-moon');
+  });
+});
+</script>
 </body>
 </html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,46 @@
+<?php
+session_start();
+require_once 'auth.php';
+
+if (isset($_SESSION['user'])) {
+    header('Location: index.php');
+    exit;
+}
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $u = $_POST['username'] ?? '';
+    $p = $_POST['password'] ?? '';
+    if (isset($USERS[$u]) && $USERS[$u] === $p) {
+        $_SESSION['user'] = $u;
+        header('Location: index.php');
+        exit;
+    }
+    $error = 'Invalid credentials';
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-5">
+<h1 class="mb-4">CCTV Login</h1>
+<?php if ($error): ?>
+<div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+<?php endif; ?>
+<form method="post" class="w-25">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input type="text" name="username" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');
+exit;
+?>

--- a/snapshot.php
+++ b/snapshot.php
@@ -1,0 +1,37 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+require_once 'camera_utils.php';
+$cams = json_decode(file_get_contents('cameras.json'), true) ?? [];
+$id = $_GET['id'] ?? '';
+$cam = null;
+foreach ($cams as $c) {
+    if (($c['id'] ?? '') === $id) { $cam = $c; break; }
+}
+if (!$cam) {
+    http_response_code(404);
+    exit('Camera not found');
+}
+$url = snapshot_url($cam);
+if (!$url) {
+    http_response_code(500);
+    exit('Unsupported camera');
+}
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+$data = curl_exec($ch);
+$ct = curl_getinfo($ch, CURLINFO_CONTENT_TYPE) ?: 'image/jpeg';
+$status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+if ($data === false || $status >= 400) {
+    http_response_code(502);
+    exit('Failed to fetch snapshot');
+}
+header('Content-Type: ' . $ct);
+header('Cache-Control: no-cache');
+echo $data;
+?>

--- a/snapshot.php
+++ b/snapshot.php
@@ -9,7 +9,7 @@ $cams = json_decode(file_get_contents('cameras.json'), true) ?? [];
 $id = $_GET['id'] ?? '';
 $cam = null;
 foreach ($cams as $c) {
-    if (($c['id'] ?? '') === $id) { $cam = $c; break; }
+    if (slugify($c['name']) === $id) { $cam = $c; break; }
 }
 if (!$cam) {
     http_response_code(404);
@@ -23,6 +23,10 @@ if (!$url) {
 $ch = curl_init($url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+if (!empty($cam['username']) || !empty($cam['password'])) {
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+    curl_setopt($ch, CURLOPT_USERPWD, ($cam['username'] ?? '').':' . ($cam['password'] ?? ''));
+}
 $data = curl_exec($ch);
 $ct = curl_getinfo($ch, CURLINFO_CONTENT_TYPE) ?: 'image/jpeg';
 $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
## Summary
- add `camera_utils.php` with functions to generate snapshot and panel URLs
- add sample `cameras.json` with optional `mac` field
- expand README with usage notes
- add login flow and Leaflet map

## Testing
- `php -l auth.php camera_utils.php index.php login.php logout.php`


------
https://chatgpt.com/codex/tasks/task_e_684811927dcc8323b0f7a56859bbf03a