### PR TITLE
Improve error if cURL not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Snapshots are fetched server-side. The helper functions build the vendor-specifi
 
 1. Install PHP (only the CLI is required). On Debian/Ubuntu:
    ```sh
-   sudo apt-get install php-cli
+   sudo apt-get install php-cli php-curl
    ```
 2. Start the built-in PHP server from the repository root:
    ```sh

--- a/camera_utils.php
+++ b/camera_utils.php
@@ -1,6 +1,8 @@
 <?php
 function slugify(string $text): string {
-    $text = iconv('UTF-8', 'ASCII//TRANSLIT', $text);
+    if (function_exists('iconv')) {
+        $text = iconv('UTF-8', 'ASCII//TRANSLIT', $text);
+    }
     $text = strtolower($text);
     $text = preg_replace('/[^a-z0-9]+/', '-', $text);
     $text = trim($text, '-');

--- a/snapshot.php
+++ b/snapshot.php
@@ -20,6 +20,10 @@ if (!$url) {
     http_response_code(500);
     exit('Unsupported camera');
 }
+if (!function_exists('curl_init')) {
+    http_response_code(500);
+    exit('Missing cURL extension');
+}
 $ch = curl_init($url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);


### PR DESCRIPTION
## Summary
- install php-curl in README
- detect missing cURL extension in `snapshot.php`

## Testing
- `php -m | grep curl`
- `curl -I http://localhost:8000/snapshot.php?id=wejscie-glowne-ptz`

------
https://chatgpt.com/codex/tasks/task_e_684833ddb4d48323abe879cbadcbd8e7